### PR TITLE
Fix GCC_TOOL only available by mistake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ find_package(Git REQUIRED)
 
 # Install "CMake Scripts" dependency
 include(FetchContent)
-FetchContent_Declare("rsp-cmake-scripts" GIT_REPOSITORY "https://github.com/rsps/cmake-scripts" GIT_TAG "v0.2.0")
+FetchContent_Declare("rsp-cmake-scripts" GIT_REPOSITORY "https://github.com/rsps/cmake-scripts" GIT_TAG "v0.3.0")
 FetchContent_MakeAvailable("rsp-cmake-scripts")
 
 # Abort if building in-source
@@ -50,7 +50,7 @@ endif()
 
 # Obtain GCC info.
 include("rsp/compiler")
-gcc_version(OUTPUT GCC_TOOL_VERSION)
+gcc_info(OUTPUT GCC_TOOL)
 
 # Define CPP standards, ...etc
 set(CMAKE_CXX_STANDARD 23)


### PR DESCRIPTION
Replaced the gcc_version() call with the new gcc_info(), which ensures to populate GCC_TOOL and GCC_TOOL_VERSION.