### PR TITLE
CMake build fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,6 +141,8 @@ add_subdirectory(src)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 
 if (BUILD_TESTING)
+    enable_testing()
+
     # Define "test binary" such that dev-dependencies can include or link
     # resources for it...
     set(TEST_BINARY "rsp-core-lib-test")

--- a/cmake/external/doctest.cmake
+++ b/cmake/external/doctest.cmake
@@ -8,11 +8,7 @@ include_guard(GLOBAL)
 # Debug
 message(VERBOSE "Installing Doctest")
 
-set(DOCTEST_VERSION "2.4.11")
-
-# NOTE: This can yield a strange DEPRECATION WARNING, which has yet to be resolved by the provider!
-# @see https://github.com/doctest/doctest/issues/893
-# @see https://github.com/doctest/doctest/issues/854
+set(DOCTEST_VERSION "2.4.12")
 
 CPMAddPackage(
     NAME "DocTest"


### PR DESCRIPTION
This PR has two small fixes to the CMake build:
- fix build for CMake > 4.0 by updating the doctest version to get the upstream fix, and
- fix registering the test binary to CTest.
