### PR TITLE
Fix working directory for CTest

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -81,7 +81,7 @@ target_link_libraries (${TEST_BINARY}
 )
 
 # Add "test binary" as a CTest test...
-add_test("tests" ${TEST_BINARY})
+add_test(NAME "tests" COMMAND ${TEST_BINARY} WORKING_DIRECTORY "${CMAKE_BINARY_DIR}")
 
 # Test files...
 file(GLOB_RECURSE SRC_FILES *.cpp)


### PR DESCRIPTION
#12 got the test executable registered to CTest, but it still wasn't able to find the executable at runtime. CTest was looking for the test binary in the build/tests/ subdir, but the executable is really in the build/ dir. This PR fixes that.