### PR TITLE
Cross compile for arm7

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -49,6 +49,44 @@
             "cacheVariables": {
                 "BUILD_TESTING": "ON"
             }
+        },
+        {
+            "name": "arm-common",
+            "hidden": true,
+            "inherits": "common",
+            "cacheVariables": {
+                "CMAKE_C_FLAGS": "-D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64",
+                "CMAKE_CXX_FLAGS": "-D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64",
+                "CMAKE_TOOLCHAIN_FILE": "/opt/arm-buildroot-linux-gnueabihf_sdk-buildroot/share/buildroot/toolchainfile.cmake"
+            }
+        },
+        {
+            "name": "arm-debug",
+            "displayName": "ARM Debug",
+            "inherits": [
+                "arm-common",
+                "debug"
+            ],
+            "binaryDir": "${sourceDir}/build/arm-debug"
+        },
+        {
+            "name": "arm-debug-with-tests",
+            "displayName": "ARM Debug + Tests",
+            "inherits": "arm-debug"
+        },
+        {
+            "name": "arm-release",
+            "displayName": "ARM Release",
+            "inherits": [
+                "arm-common",
+                "release"
+            ],
+            "binaryDir": "${sourceDir}/build/arm-release"
+        },
+        {
+            "name": "arm-release-with-tests",
+            "displayName": "ARM Release + Tests",
+            "inherits": "arm-release"
         }
     ],
     "buildPresets": [
@@ -67,6 +105,22 @@
         {
             "name": "release-with-tests",
             "configurePreset": "release-with-tests"
+        },
+        {
+            "name": "arm-debug",
+            "configurePreset": "arm-debug"
+        },
+        {
+            "name": "arm-debug-with-tests",
+            "configurePreset": "arm-debug-with-tests"
+        },
+        {
+            "name": "arm-release",
+            "configurePreset": "arm-release"
+        },
+        {
+            "name": "arm-release-with-tests",
+            "configurePreset": "arm-release-with-tests"
         }
     ],
     "testPresets": [

--- a/cmake/FindSDL2.cmake
+++ b/cmake/FindSDL2.cmake
@@ -1,0 +1,52 @@
+# FindSDL2.cmake
+# ---------------
+# Find the SDL2 library and headers.
+#
+# Result Variables:
+#
+#   SDL2_FOUND        - System has SDL2
+#   SDL2_INCLUDE_DIRS - The SDL2 include directories
+#   SDL2_LIBRARIES    - The libraries needed to link SDL2
+#
+# Imported Targets:
+#
+#   SDL2::SDL2 - Target for SDL2 library
+#
+
+# Try config mode first (for when system has SDL2 installed with CMake support)
+find_package(SDL2 CONFIG QUIET)
+
+# Fallback if config mode failed
+if(NOT SDL2_FOUND)
+    find_path(SDL2_INCLUDE_DIR
+        NAMES SDL.h
+        PATH_SUFFIXES SDL2
+    )
+    mark_as_advanced(SDL2_INCLUDE_DIR)
+
+    find_library(SDL2_LIBRARY
+        NAMES SDL2
+    )
+    mark_as_advanced(SDL2_LIBRARY)
+
+    include(FindPackageHandleStandardArgs)
+    find_package_handle_standard_args(SDL2
+        DEFAULT_MSG
+        SDL2_LIBRARY SDL2_INCLUDE_DIR
+    )
+
+    if(SDL2_FOUND)
+        set(SDL2_LIBRARIES ${SDL2_LIBRARY})
+        set(SDL2_INCLUDE_DIRS ${SDL2_INCLUDE_DIR})
+
+        if(NOT TARGET SDL2::SDL2)
+            add_library(SDL2::SDL2 UNKNOWN IMPORTED)
+            set_target_properties(SDL2::SDL2 PROPERTIES
+                INTERFACE_INCLUDE_DIRECTORIES "${SDL2_INCLUDE_DIR}"
+                IMPORTED_LOCATION "${SDL2_LIBRARY}"
+                IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+            )
+        endif()
+    endif()
+endif()
+

--- a/cmake/Findwpa_supplicant.cmake
+++ b/cmake/Findwpa_supplicant.cmake
@@ -14,13 +14,13 @@
 #
 
 find_path(wpa_supplicant_INCLUDE_DIR
-  NAMES wpa_ctrl.h
-  PATH_SUFFIXES wpa_supplicant
+    NAMES wpa_ctrl.h
+    PATH_SUFFIXES wpa_supplicant
 )
 mark_as_advanced(wpa_supplicant_INCLUDE_DIR)
 
 find_library(wpa_supplicant_LIBRARY
-  NAMES wpa_client
+    NAMES wpa_client
 )
 mark_as_advanced(wpa_supplicant_LIBRARY)
 
@@ -35,7 +35,14 @@ if(wpa_supplicant_FOUND)
     set(wpa_supplicant_INCLUDE_DIRS ${wpa_supplicant_INCLUDE_DIR})
 
     if(NOT TARGET wpa_supplicant::wpa_supplicant)
-        add_library(wpa_supplicant::wpa_supplicant UNKNOWN IMPORTED)
+        if(wpa_supplicant_LIBRARY MATCHES "\\.(a|lib)$")
+            add_library(wpa_supplicant::wpa_supplicant STATIC IMPORTED)
+        else()
+            add_library(wpa_supplicant::wpa_supplicant SHARED IMPORTED)
+            set_target_properties(wpa_supplicant::wpa_supplicant PROPERTIES
+                IMPORTED_NO_SONAME TRUE # libwpa_client.so lacks SONAME in its ELF headers
+            )
+        endif()
         set_target_properties(wpa_supplicant::wpa_supplicant PROPERTIES
             INTERFACE_INCLUDE_DIRECTORIES "${wpa_supplicant_INCLUDE_DIR}"
             IMPORTED_LOCATION "${wpa_supplicant_LIBRARY}"

--- a/cmake/Findwpa_supplicant.cmake
+++ b/cmake/Findwpa_supplicant.cmake
@@ -1,0 +1,45 @@
+# Findwpa_supplicant.cmake
+# ------------------------
+# Find the wpa_supplicant client library and headers.
+#
+# Result Variables:
+#
+#   wpa_supplicant_FOUND        - System has wpa_supplicant
+#   wpa_supplicant_INCLUDE_DIRS - The wpa_supplicant include directories
+#   wpa_supplicant_LIBRARIES    - The libraries needed to use wpa_supplicant
+#
+# Imported Targets:
+#
+#   wpa_supplicant::wpa_supplicant - Target for wpa_supplicant library
+#
+
+find_path(wpa_supplicant_INCLUDE_DIR
+  NAMES wpa_ctrl.h
+  PATH_SUFFIXES wpa_supplicant
+)
+mark_as_advanced(wpa_supplicant_INCLUDE_DIR)
+
+find_library(wpa_supplicant_LIBRARY
+  NAMES wpa_client
+)
+mark_as_advanced(wpa_supplicant_LIBRARY)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(wpa_supplicant
+    DEFAULT_MSG
+    wpa_supplicant_LIBRARY wpa_supplicant_INCLUDE_DIR
+)
+
+if(wpa_supplicant_FOUND)
+    set(wpa_supplicant_LIBRARIES ${wpa_supplicant_LIBRARY})
+    set(wpa_supplicant_INCLUDE_DIRS ${wpa_supplicant_INCLUDE_DIR})
+
+    if(NOT TARGET wpa_supplicant::wpa_supplicant)
+        add_library(wpa_supplicant::wpa_supplicant UNKNOWN IMPORTED)
+        set_target_properties(wpa_supplicant::wpa_supplicant PROPERTIES
+            INTERFACE_INCLUDE_DIRECTORIES "${wpa_supplicant_INCLUDE_DIR}"
+            IMPORTED_LOCATION "${wpa_supplicant_LIBRARY}"
+            IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+        )
+    endif()
+endif()

--- a/cmake/external/wpa-supplicant.cmake
+++ b/cmake/external/wpa-supplicant.cmake
@@ -13,19 +13,9 @@ message(VERBOSE "Installing WPA Supplicant")
 # NOTE: This is a runtime dependency that SHOULD be installed on the system
 #       sudo apt install libwpa-client-dev
 
-# find_package(WPA_SUPPLICANT REQUIRED) # NOT going to work without a custom `FindWPASupplicant` module
+find_package(wpa_supplicant REQUIRED)
 
-find_library(wpa_supplicant NAMES "wpa_client" DOC " RSP Core Lib - Path to WPA Supplicant Library (libwpa-client-dev)")
-
-# Debug
-if (wpa_supplicant STREQUAL "wpa_supplicant-NOTFOUND")
-    message(STATUS "WPA Supplicant (${COLOR_RED}${TEXT_ITALIC}not found${RESTORE})")
-else ()
-    message(STATUS "Using WPA Supplicant (${COLOR_WHITE}${TEXT_ITALIC}${wpa_supplicant}${RESTORE})")
-endif ()
-
-# Include & link...
-target_link_libraries(${PROJECT_NAME} wpa_client)
+target_link_libraries(${PROJECT_NAME} wpa_supplicant::wpa_supplicant)
 
 # -------------------------------------------------------------------------------------------------------------- #
 

--- a/include/network/StatusLine.h
+++ b/include/network/StatusLine.h
@@ -22,7 +22,7 @@ public:
     explicit StatusLine(HttpText aStatusLine)
     {
         mHttpVersion = aStatusLine.HttpVersion();
-        mStatusCode = aStatusLine.Digit(3);
+        mStatusCode = static_cast<int>(aStatusLine.Digit(3));
         aStatusLine.SP();
         mReasonPhrase = aStatusLine.AsciiText();
     }

--- a/include/utils/AbstractIterator.h
+++ b/include/utils/AbstractIterator.h
@@ -31,12 +31,18 @@ struct AbstractIterator
     using reference         = value_type &;
     using size_type         = size_t;
 
-    constexpr auto cAdd(pointer aPtr, difference_type aOffset) {
+    constexpr auto cAdd(pointer aPtr, difference_type aOffset)
+    {
+        // This two-step cast through void* suppresses -Wcast-align: casting
+        // from uint8_t* (1-byte alignment) to IElement* (higher alignment).
+        // This is OK because the offset is always a multiple of mElementSize.
         if constexpr (std::is_const_v<value_type>) {
-            return reinterpret_cast<pointer>(reinterpret_cast<const uint8_t *>(aPtr) + (aOffset * difference_type(mElementSize)));
+            auto* byte_ptr = reinterpret_cast<const uint8_t*>(aPtr) + (aOffset * difference_type(mElementSize));
+            return static_cast<pointer>(static_cast<const void*>(byte_ptr));
         }
         else {
-            return reinterpret_cast<pointer>(reinterpret_cast<uint8_t *>(aPtr) + (aOffset * difference_type(mElementSize)));
+            auto* byte_ptr = reinterpret_cast<uint8_t*>(aPtr) + (aOffset * difference_type(mElementSize));
+            return static_cast<pointer>(static_cast<void*>(byte_ptr));
         }
     }
 
@@ -70,7 +76,7 @@ public:
     AbstractIterator& operator+=(const difference_type offset) { mPtr = cAdd(mPtr, offset); return *this; }
 
     // Prefix increment
-    AbstractIterator& operator++() { mPtr = cAdd(mPtr, 1);; return *this; }
+    AbstractIterator& operator++() { mPtr = cAdd(mPtr, 1); return *this; }
 
     // Postfix increment
     AbstractIterator operator++(int) { auto tmp = *this; ++(*this); return tmp; }

--- a/src/graphics/PixelData.cpp
+++ b/src/graphics/PixelData.cpp
@@ -8,11 +8,28 @@
  * \author      Steffen Brummer
  */
 
+#include <cassert>
 #include <cstring>
 #include <graphics/PixelData.h>
 #include <utils/Crc32.h>
 #include <utils/CppObjectFile.h>
 #include <utils/StrUtils.h>
+
+namespace {
+
+constexpr uint32_t* assume_aligned_u32(uint8_t* p)
+{
+    assert((reinterpret_cast<uintptr_t>(p) % alignof(uint32_t)) == 0);
+    return static_cast<uint32_t*>(static_cast<void*>(p));
+}
+
+constexpr const uint32_t* assume_aligned_u32(const uint8_t* p)
+{
+    assert((reinterpret_cast<uintptr_t>(p) % alignof(uint32_t)) == 0);
+    return static_cast<const uint32_t*>(static_cast<const void*>(p));
+}
+
+} // namespace
 
 namespace rsp::graphics {
 
@@ -197,7 +214,7 @@ Color PixelData::GetPixelAt(const GuiUnit_t aX, const GuiUnit_t aY, const Color 
 
         case ColorDepth::RGBA:
             offset = ((aY * GetWidth()) + aX) * 4;
-            result.FromRaw(*reinterpret_cast<const uint32_t*>(reinterpret_cast<uintptr_t>(mpData + offset)));
+            result.FromRaw(*assume_aligned_u32(mpData + offset));
             break;
 
         default:
@@ -253,12 +270,12 @@ PixelData& PixelData::SetPixelAt(const GuiUnit_t aX, const GuiUnit_t aY, const C
         case ColorDepth::RGBA:
             offset = ((aY * GetWidth()) + aX) * 4;
             if (!mBlend || arColor.GetAlpha() == 255) {
-                *reinterpret_cast<uint32_t*>(p_data + offset) = arColor.AsRaw();
+                *assume_aligned_u32(p_data + offset) = arColor.AsRaw();
             }
             else {
                 Color bg;
-                bg.FromRaw(*reinterpret_cast<uint32_t*>(p_data + offset));
-                *reinterpret_cast<uint32_t*>(p_data + offset) = Color::Blend(bg, arColor).AsRaw();
+                bg.FromRaw(*assume_aligned_u32(p_data + offset));
+                *assume_aligned_u32(p_data + offset) = Color::Blend(bg, arColor).AsRaw();
             }
             break;
 
@@ -392,8 +409,7 @@ void PixelData::Fill(const Color& arColor)
     }
     switch (mColorDepth) {
         case ColorDepth::RGBA: {
-            auto *p = reinterpret_cast<uint32_t*>(mData.data());
-            std::fill_n(p, mData.size() / sizeof(uint32_t), arColor.AsRaw());
+            std::fill_n(assume_aligned_u32(mData.data()), mData.size() / sizeof(uint32_t), arColor.AsRaw());
             break;
         }
 
@@ -434,7 +450,7 @@ PixelData& PixelData::Fade(const int aAlphaInc, const bool aFixed)
         for (GuiUnit_t x = 0 ; x < GetWidth() ; x++) {
             const int offset = ((y * GetWidth()) + x) * 4;
             Color col;
-            col.FromRaw(*reinterpret_cast<const uint32_t*>(p_data + offset));
+            col.FromRaw(*assume_aligned_u32(p_data + offset));
             if (col == Color::None) {
                 continue;
             }
@@ -450,7 +466,7 @@ PixelData& PixelData::Fade(const int aAlphaInc, const bool aFixed)
                 alpha = std::max(alpha + aAlphaInc, 0);
             }
             col.SetAlpha(static_cast<uint8_t>(alpha));
-            *reinterpret_cast<uint32_t*>(p_data + offset) = col.AsRaw();
+            *assume_aligned_u32(p_data + offset) = col.AsRaw();
         }
     }
     return *this;

--- a/src/security/openssl/ShaDigestImpl.cpp
+++ b/src/security/openssl/ShaDigestImpl.cpp
@@ -107,7 +107,7 @@ public:
         params[0] = OSSL_PARAM_construct_utf8_string("digest", algo.data(), 0);
         params[1] = OSSL_PARAM_construct_end();
 
-        EVP_MAC_init(mpCtx, arSecret.data(), static_cast<unsigned long int>(arSecret.size()), params);
+        EVP_MAC_init(mpCtx, arSecret.data(), arSecret.size(), params);
     }
 
     ~OpenSSLHMac() override
@@ -121,13 +121,13 @@ public:
 
     void Update(const uint8_t *apBuffer, std::size_t aSize) override
     {
-        EVP_MAC_update(mpCtx, apBuffer, static_cast<unsigned long int>(aSize));
+        EVP_MAC_update(mpCtx, apBuffer, aSize);
     }
 
     SecureBuffer Finalize() override
     {
         SecureBuffer result;
-        unsigned long int len;
+        std::size_t len;
 
         EVP_MAC_final(mpCtx, nullptr, &len, 0);
         result.resize(len);
@@ -183,7 +183,7 @@ public:
 
     void Update(const uint8_t *apBuffer, std::size_t aSize) override
     {
-        EVP_DigestUpdate(mpMdctx, apBuffer, static_cast<unsigned long int>(aSize));
+        EVP_DigestUpdate(mpMdctx, apBuffer, aSize);
     }
 
     SecureBuffer Finalize() override

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -94,7 +94,9 @@ target_sources(${TEST_BINARY}
         ${SRC_FILES}
 )
 
-doctest_discover_tests(${TEST_BINARY} WORKING_DIRECTORY "${CMAKE_BINARY_DIR}")
+if(NOT CMAKE_CROSSCOMPILING)
+    doctest_discover_tests(${TEST_BINARY} WORKING_DIRECTORY "${CMAKE_BINARY_DIR}")
+endif()
 
 # -------------------------------------------------------------------------------------------------------------- #
 # Install / Export

--- a/tests/unit/network/test-DataProviders.cpp
+++ b/tests/unit/network/test-DataProviders.cpp
@@ -170,7 +170,7 @@ TEST_CASE("Data Providers")
         size_t max_size = 7;
         while (auto sz = cs.Read({reinterpret_cast<std::byte*>(buffer.data()), max_size})) {
             result += std::string(buffer.data(), sz);
-            max_size = rsp::utils::Random::Roll(1ul, buffer.size());
+            max_size = rsp::utils::Random::Roll(std::size_t{1}, buffer.size());
         }
 
         CHECK_EQ(result.size(), cPayload.size());


### PR DESCRIPTION
This PR contains misc. fixes for compilation warnings (promoted to errors) when building for arm7 with GCC 14.3 (arm-buildroot-linux-gnueabihf).

The CMake presets assumes the Buildroot SDK to be installed at `/opt/arm-buildroot-linux-gnueabihf_sdk-buildroot`.