### PR TITLE
Hardening and bugfixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,7 @@ target_include_directories(${PROJECT_NAME}
 # Compile options
 include("cmake/gcc-compile-options.cmake")
 target_compile_options(${PROJECT_NAME} PRIVATE "${RSP_GCC_STRICT_COMPILE_OPTIONS}")
+target_compile_definitions(${PROJECT_NAME} PRIVATE ${RSP_GCC_STRICT_COMPILE_DEFINITIONS})
 
 # Macro definitions per build configuration
 target_compile_definitions(${PROJECT_NAME} PRIVATE "$<$<CONFIG:DEBUG>:DEBUG_LOG>")

--- a/cmake/gcc-compile-options.cmake
+++ b/cmake/gcc-compile-options.cmake
@@ -188,4 +188,23 @@ if (NOT DEFINED RSP_GCC_STRICT_COMPILE_OPTIONS)
         #
         #-dD
     )
+
+    if(NOT DEFINED RSP_GCC_STRICT_COMPILE_DEFINITIONS)
+        set(RSP_GCC_STRICT_COMPILE_DEFINITIONS
+            # Lightweight checks to detect some buffer overflow errors when
+            # employing various string and memory manipulation functions.
+            #
+            # @see https://man7.org/linux/man-pages/man7/feature_test_macros.7.html
+            # @see https://developers.redhat.com/articles/2023/07/04/developers-guide-secure-coding-fortifysource
+            #
+            -D_FORTIFY_SOURCE=3
+
+            # Lightweight assertions that do not catch as many problems, but
+            # which are ABI compatible with normal mode.
+            #
+            # @see https://gcc.gnu.org/onlinedocs/libstdc++/manual/using_macros.html
+            #
+            -D_GLIBCXX_ASSERTIONS
+        )
+    endif()
 endif()

--- a/include/utils/Base64.h
+++ b/include/utils/Base64.h
@@ -1,22 +1,23 @@
 /**
-* This Source Code Form is subject to the terms of the Mozilla Public
-* License, v. 2.0. If a copy of the MPL was not distributed with this
-* file, You can obtain one at https://mozilla.org/MPL/2.0/.
-*
-* \copyright   Copyright 2025 RSP Systems A/S. All rights reserved.
-* \license     Mozilla Public License 2.0
-* \author      steffen
-*/
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * \copyright   Copyright 2025 RSP Systems A/S. All rights reserved.
+ * \license     Mozilla Public License 2.0
+ * \author      steffen
+ */
 #ifndef RSP_CORE_LIB_INCLUDE_UTILS_BASE64_H
 #define RSP_CORE_LIB_INCLUDE_UTILS_BASE64_H
 
 #include <span>
 #include <string>
+#include <string_view>
 #include <exceptions/CoreException.h>
 
 namespace rsp::utils {
 
-class EBase64FormatError: public exceptions::CoreException
+class EBase64FormatError : public exceptions::CoreException
 {
 public:
     using rsp::exceptions::CoreException::CoreException;
@@ -30,14 +31,15 @@ class Base64
 {
 public:
     static std::string Encode(std::span<const std::byte> aData);
+
     static std::string Encode(std::string_view aText)
     {
-        return Encode({ reinterpret_cast<const std::byte*>(aText.data()), aText.size() });
+        return Encode(std::as_bytes(std::span{aText}));
     }
 
     static std::string Decode(std::string_view aBase64);
 };
 
-} // rsp::utils
+} // namespace rsp::utils
 
-#endif //RSP_CORE_LIB_INCLUDE_UTILS_BASE64_H
+#endif // RSP_CORE_LIB_INCLUDE_UTILS_BASE64_H

--- a/src/posix/SocketAddress.cpp
+++ b/src/posix/SocketAddress.cpp
@@ -160,10 +160,8 @@ std::string SocketAddress::GetCanonicalName() const
 
         default:
         case Domain::Unspecified:
-            result.resize(sizeof(mAddress.Unspecified.sa_data) + 1);
-            result.back() = '\0';
-            std::strncpy(result.data(), mAddress.Unspecified.sa_data, sizeof(mAddress) - sizeof(uint16_t));
-            result.shrink_to_fit();
+            result.assign(mAddress.Unspecified.sa_data,
+                          strnlen(mAddress.Unspecified.sa_data, sizeof(mAddress.Unspecified.sa_data)));
             break;
     }
     return result;

--- a/src/utils/Base64.cpp
+++ b/src/utils/Base64.cpp
@@ -8,7 +8,7 @@
  * \author      steffen
  */
 #include <utils/Base64.h>
-#include <cinttypes>
+#include <cstdint>
 
 namespace rsp::utils {
 
@@ -17,12 +17,17 @@ constexpr char cPadding = '=';
 std::string Base64::Encode(std::span<const std::byte> aData)
 {
     std::string result;
-    result.reserve(aData.size() * 4 / 3);
+    result.reserve((aData.size() + 2) / 3 * 4);
 
     for (size_t i = 0; i < aData.size(); i += 3) {
-        uint32_t work = (uint32_t(aData[i + 0]) << 16)
-                        | (uint32_t(aData[i + 1]) << 8)
-                        | (uint32_t(aData[i + 2]));
+        size_t remaining = aData.size() - i;
+        uint32_t work = (uint32_t(aData[i]) << 16);
+        if (remaining > 1) {
+            work |= (uint32_t(aData[i + 1]) << 8);
+        }
+        if (remaining > 2) {
+            work |= uint32_t(aData[i + 2]);
+        }
 
         for (size_t b = 0; b < 4; ++b) {
             size_t sextet = (work >> 18) & 0x3F;

--- a/src/utils/Base64.cpp
+++ b/src/utils/Base64.cpp
@@ -1,12 +1,12 @@
 /**
-* This Source Code Form is subject to the terms of the Mozilla Public
-* License, v. 2.0. If a copy of the MPL was not distributed with this
-* file, You can obtain one at https://mozilla.org/MPL/2.0/.
-*
-* \copyright   Copyright 2025 RSP Systems A/S. All rights reserved.
-* \license     Mozilla Public License 2.0
-* \author      steffen
-*/
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * \copyright   Copyright 2025 RSP Systems A/S. All rights reserved.
+ * \license     Mozilla Public License 2.0
+ * \author      steffen
+ */
 #include <utils/Base64.h>
 #include <cinttypes>
 
@@ -19,12 +19,12 @@ std::string Base64::Encode(std::span<const std::byte> aData)
     std::string result;
     result.reserve(aData.size() * 4 / 3);
 
-    for (size_t i = 0; i < aData.size() ; i += 3) {
-        uint32_t work = (uint32_t(aData[i+0]) << 16)
-             | (uint32_t(aData[i+1]) << 8)
-             | (uint32_t(aData[i+2]));
+    for (size_t i = 0; i < aData.size(); i += 3) {
+        uint32_t work = (uint32_t(aData[i + 0]) << 16)
+                        | (uint32_t(aData[i + 1]) << 8)
+                        | (uint32_t(aData[i + 2]));
 
-        for (size_t b = 0 ; b < 4 ; ++b) {
+        for (size_t b = 0; b < 4; ++b) {
             size_t sextet = (work >> 18) & 0x3F;
             if (sextet < 26) {
                 result += char('A' + sextet);
@@ -111,11 +111,11 @@ std::string Base64::Decode(std::string_view aBase64)
     return result;
 }
 
-//std::array<char, 64> Base64::mMap64{
-//    'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P',
-//    'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', 'a', 'b', 'c', 'd', 'e', 'f',
-//    'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v',
-//    'w', 'x', 'y', 'z', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '+', '/'
-//};
+// std::array<char, 64> Base64::mMap64{
+//     'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P',
+//     'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', 'a', 'b', 'c', 'd', 'e', 'f',
+//     'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v',
+//     'w', 'x', 'y', 'z', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '+', '/'
+// };
 
-} // rsp::utils
+} // namespace rsp::utils

--- a/tests/unit/utils/test-Base64.cpp
+++ b/tests/unit/utils/test-Base64.cpp
@@ -1,12 +1,12 @@
 /**
-* This Source Code Form is subject to the terms of the Mozilla Public
-* License, v. 2.0. If a copy of the MPL was not distributed with this
-* file, You can obtain one at https://mozilla.org/MPL/2.0/.
-*
-* \copyright   Copyright 2025 RSP Systems A/S. All rights reserved.
-* \license     Mozilla Public License 2.0
-* \author      steffen
-*/
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * \copyright   Copyright 2025 RSP Systems A/S. All rights reserved.
+ * \license     Mozilla Public License 2.0
+ * \author      steffen
+ */
 #include <doctest.h>
 #include <utils/Base64.h>
 


### PR DESCRIPTION
Enable library hardening by setting macros `_FORTIFY_SOURCE=3` and `_GLIBCXX_ASSERTIONS`. This revealed a couple of bugs which are then fixed.