### PR TITLE
Remove dead thread-safety code and move ctor/assign from Singleton

### DIFF
--- a/include/utils/Singleton.h
+++ b/include/utils/Singleton.h
@@ -11,9 +11,6 @@
 #ifndef RSP_CORE_LIB_UTILS_SINGLETON_H
 #define RSP_CORE_LIB_UTILS_SINGLETON_H
 
-#ifdef MT
-#include <mutex>
-#endif
 #include <exceptions/CoreException.h>
 #include "ConstTypeInfo.h"
 
@@ -22,6 +19,8 @@ namespace rsp::utils {
 /**
  * \class Singleton
  * \brief Testable singleton pattern implemented as template class.
+ *
+ * \warning This class is not thread safe during creation and destruction of the instance.
  *
  * Usage:
  *   class MyClass : public Singleton<MyClass> {}
@@ -85,9 +84,6 @@ public:
     template <typename... Args>
     static void CreateInstance(Args&&... args)
     {
-#ifdef MT
-        std::lock_guard<std::mutex> lock(mMutex);
-#endif
         if (mpInstance) {
             THROW_WITH_BACKTRACE1(exceptions::ESingletonViolation, NameOf<T>());
         }
@@ -106,9 +102,6 @@ public:
      */
     static void SetInstance(T* apObject)
     {
-#ifdef MT
-        std::lock_guard<std::mutex> lock(mMutex);
-#endif
         if (mpInstance && mOwnsInstance) {
             THROW_WITH_BACKTRACE1(exceptions::ESingletonViolation, NameOf<T>());
         }
@@ -135,9 +128,6 @@ public:
      */
     static void DestroyInstance()
     {
-#ifdef MT
-        std::lock_guard<std::mutex> lock(mMutex);
-#endif
         if (mpInstance && mOwnsInstance) {
             mOwnsInstance = false;
             delete mpInstance;
@@ -146,18 +136,9 @@ public:
     }
 
 private:
-#ifdef MT
-    static std::mutex mMutex;
-#endif
-    static T* mpInstance;
-    static bool mOwnsInstance;
+    static inline T* mpInstance = nullptr;
+    static inline bool mOwnsInstance = false;
 };
-
-template <class T>
-T* Singleton<T>::mpInstance = nullptr;
-
-template <class T>
-bool Singleton<T>::mOwnsInstance = false;
 
 } /* namespace rsp::utils */
 

--- a/include/utils/Singleton.h
+++ b/include/utils/Singleton.h
@@ -8,7 +8,6 @@
  * \author      Steffen Brummer
  */
 
-
 #ifndef RSP_CORE_LIB_UTILS_SINGLETON_H
 #define RSP_CORE_LIB_UTILS_SINGLETON_H
 
@@ -20,7 +19,6 @@
 
 namespace rsp::utils {
 
-
 /**
  * \class Singleton
  * \brief Testable singleton pattern implemented as template class.
@@ -30,7 +28,7 @@ namespace rsp::utils {
  *
  * \tparam T
  */
-template<class T>
+template <class T>
 class Singleton
 {
 public:
@@ -42,31 +40,32 @@ public:
     /**
      * \brief Prohibit copy of Singleton
      */
-    Singleton(const Singleton<T> &) = delete;
+    Singleton(const Singleton<T>&) = delete;
 
     /**
      * \brief Move constructor
      * \param other
      */
-    Singleton(Singleton<T> &&) = default;
+    Singleton(Singleton<T>&&) = default;
 
     virtual ~Singleton() = default;
 
     /**
      * \brief Prohibit singleton assignment.
      */
-    Singleton& operator=(const Singleton &) = delete;
+    Singleton& operator=(const Singleton&) = delete;
 
     /**
      * \brief Move assignment
      */
-    Singleton& operator=(Singleton &&) = default;
+    Singleton& operator=(Singleton&&) = default;
 
     /**
      * \brief Check if this singleton is instantiated
      * \return bool
      */
-    static bool HasInstance() {
+    static bool HasInstance()
+    {
         return (mpInstance);
     }
 
@@ -74,7 +73,8 @@ public:
      * \brief Check is this singleton instance is self owned
      * \return bool
      */
-    static bool OwnsInstance() {
+    static bool OwnsInstance()
+    {
         return mOwnsInstance;
     }
 
@@ -82,8 +82,9 @@ public:
      * \fn void Create(...)
      * \brief Generic factory method.
      */
-    template<typename... Args>
-    static void CreateInstance(Args &&... args) {
+    template <typename... Args>
+    static void CreateInstance(Args&&... args)
+    {
 #ifdef MT
         std::lock_guard<std::mutex> lock(mMutex);
 #endif
@@ -103,7 +104,8 @@ public:
      *
      * \param aObject
      */
-    static void SetInstance(T* apObject) {
+    static void SetInstance(T* apObject)
+    {
 #ifdef MT
         std::lock_guard<std::mutex> lock(mMutex);
 #endif
@@ -119,7 +121,8 @@ public:
      *
      * \return
      */
-    static T& GetInstance() {
+    static T& GetInstance()
+    {
         if (!mpInstance) {
             THROW_WITH_BACKTRACE1(exceptions::ENoInstance, NameOf<T>());
         }
@@ -130,7 +133,8 @@ public:
      * \fn void Destroy()
      * \brief Call this to destroy a self owned instance. Useful during unit testing.
      */
-    static void DestroyInstance() {
+    static void DestroyInstance()
+    {
 #ifdef MT
         std::lock_guard<std::mutex> lock(mMutex);
 #endif
@@ -149,10 +153,10 @@ private:
     static bool mOwnsInstance;
 };
 
-template<class T>
+template <class T>
 T* Singleton<T>::mpInstance = nullptr;
 
-template<class T>
+template <class T>
 bool Singleton<T>::mOwnsInstance = false;
 
 } /* namespace rsp::utils */

--- a/include/utils/Singleton.h
+++ b/include/utils/Singleton.h
@@ -32,32 +32,15 @@ class Singleton
 {
 public:
     /**
-     * \brief Construct a Singleton
+     * \brief Construct an empty and non-owning Singleton
      */
     Singleton() = default;
 
-    /**
-     * \brief Prohibit copy of Singleton
-     */
-    Singleton(const Singleton<T>&) = delete;
-
-    /**
-     * \brief Move constructor
-     * \param other
-     */
-    Singleton(Singleton<T>&&) = default;
-
     virtual ~Singleton() = default;
 
-    /**
-     * \brief Prohibit singleton assignment.
-     */
+    // Prohibit copy/move operations
+    Singleton(const Singleton&) = delete;
     Singleton& operator=(const Singleton&) = delete;
-
-    /**
-     * \brief Move assignment
-     */
-    Singleton& operator=(Singleton&&) = default;
 
     /**
      * \brief Check if this singleton is instantiated
@@ -65,7 +48,7 @@ public:
      */
     static bool HasInstance()
     {
-        return (mpInstance);
+        return (mpInstance != nullptr);
     }
 
     /**

--- a/tests/unit/utils/test-singleton.cpp
+++ b/tests/unit/utils/test-singleton.cpp
@@ -8,7 +8,7 @@
  * \author      Steffen Brummer
  */
 
-#include "doctest.h"
+#include <doctest.h>
 #include <utils/Singleton.h>
 
 using namespace rsp::utils;
@@ -18,12 +18,18 @@ TEST_SUITE_BEGIN("Utils");
 
 TEST_CASE("Singleton")
 {
-
     struct MyClass : Singleton<MyClass>
     {
-        [[nodiscard]] bool Compare(int a, int b) const
-        { // NOLINT, Not static since we are testing singleton
-            return a == b;
+        int Value{0};
+
+        MyClass() = default;
+
+        explicit MyClass(int aValue)
+            : Value{aValue} {}
+
+        [[nodiscard]] bool Compare(int aValue) const
+        {
+            return Value == aValue;
         }
     };
 
@@ -32,28 +38,30 @@ TEST_CASE("Singleton")
 
         CHECK_NOTHROW(MyClass::CreateInstance());
         CHECK_NOTHROW(MyClass::GetInstance());
-        CHECK(MyClass::GetInstance().Compare(0, 0));
+        CHECK(MyClass::GetInstance().Compare(0));
 
         CHECK_THROWS_AS(MyClass::CreateInstance(), const ESingletonViolation&);
-        CHECK_THROWS_AS(MyClass::SetInstance(static_cast<MyClass*>(nullptr)), const ESingletonViolation&);
+        CHECK_THROWS_AS(MyClass::SetInstance(nullptr), const ESingletonViolation&);
 
         CHECK_NOTHROW(MyClass::DestroyInstance());
         CHECK_THROWS_AS(MyClass::GetInstance(), const ENoInstance&);
+
+        CHECK_NOTHROW(MyClass::DestroyInstance());
     }
 
     SUBCASE("External Owned") {
         CHECK_THROWS_AS(MyClass::GetInstance(), const ENoInstance&);
 
-        MyClass o;
+        MyClass o(1);
         CHECK_NOTHROW(MyClass::SetInstance(&o));
         CHECK_NOTHROW(MyClass::GetInstance());
-        CHECK(MyClass::GetInstance().Compare(1, 1));
+        CHECK(MyClass::GetInstance().Compare(1));
 
         CHECK_THROWS_AS(MyClass::CreateInstance(), const ESingletonViolation&);
         CHECK_NOTHROW(MyClass::DestroyInstance());
         CHECK_THROWS_AS(MyClass::CreateInstance(), const ESingletonViolation&);
 
-        CHECK_NOTHROW(MyClass::SetInstance(static_cast<MyClass*>(nullptr)));
+        CHECK_NOTHROW(MyClass::SetInstance(nullptr));
         CHECK_THROWS_AS(MyClass::GetInstance(), const ENoInstance&);
     }
 }

--- a/tests/unit/utils/test-singleton.cpp
+++ b/tests/unit/utils/test-singleton.cpp
@@ -16,10 +16,13 @@ using namespace rsp::exceptions;
 
 TEST_SUITE_BEGIN("Utils");
 
-TEST_CASE("Singleton") {
+TEST_CASE("Singleton")
+{
 
-    struct MyClass : Singleton<MyClass> {
-        [[nodiscard]] bool Compare(int a, int b) const { // NOLINT, Not static since we are testing singleton
+    struct MyClass : Singleton<MyClass>
+    {
+        [[nodiscard]] bool Compare(int a, int b) const
+        { // NOLINT, Not static since we are testing singleton
             return a == b;
         }
     };


### PR DESCRIPTION
This PR removes

- dead thread-safety code, and
- wrongly defaulted move ctor and move assignment operator

from the `Singleton` class.

I added in some code formatting and minor refactoring.
