### PR TITLE
Avoid forcing stdlib hardening macros in all builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,5 @@
 cmake_minimum_required(VERSION 3.23...3.30)
 
-# Set toolchain file before project() so CMake uses it during compiler detection
-option(ARCH_ARM "Set to cross-compile for ARM CPU" OFF)
-if(ARCH_ARM)
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64")
-    set(CMAKE_TOOLCHAIN_FILE "/opt/arm-buildroot-linux-gnueabihf_sdk-buildroot/share/buildroot/toolchainfile.cmake")
-endif()
-
 # Get CMake-friendly version from Git tag
 include("cmake/git.cmake")
 git_get_version(OUTPUT RSP_CORE_LIB_VERSION WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
@@ -65,7 +57,6 @@ target_include_directories(${PROJECT_NAME}
 # Compile options
 include("cmake/gcc-compile-options.cmake")
 target_compile_options(${PROJECT_NAME} PRIVATE "${RSP_GCC_STRICT_COMPILE_OPTIONS}")
-target_compile_definitions(${PROJECT_NAME} PRIVATE ${RSP_GCC_STRICT_COMPILE_DEFINITIONS})
 
 # Macro definitions per build configuration
 target_compile_definitions(${PROJECT_NAME} PRIVATE "$<$<CONFIG:DEBUG>:DEBUG_LOG>")

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -11,7 +11,13 @@
             "hidden": true,
             "generator": "Ninja",
             "cacheVariables": {
-                "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
+                "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
+                "CMAKE_C_FLAGS": "-D_GLIBCXX_ASSERTIONS",
+                "CMAKE_CXX_FLAGS": "-D_GLIBCXX_ASSERTIONS",
+                "CMAKE_C_FLAGS_DEBUG": "-g",
+                "CMAKE_CXX_FLAGS_DEBUG": "-g",
+                "CMAKE_C_FLAGS_RELEASE": "-O3 -DNDEBUG -D_FORTIFY_SOURCE=2",
+                "CMAKE_CXX_FLAGS_RELEASE": "-O3 -DNDEBUG -D_FORTIFY_SOURCE=2"
             }
         },
         {
@@ -33,21 +39,36 @@
             }
         },
         {
-            "name": "arm-debug",
-            "displayName": "ARM Debug",
-            "inherits": "debug",
-            "binaryDir": "${sourceDir}/build/arm-debug",
+            "name": "arm-buildroot-common",
+            "hidden": true,
+            "generator": "Ninja",
             "cacheVariables": {
-                "ARCH_ARM": "ON"
+                "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
+                "CMAKE_TOOLCHAIN_FILE": "/opt/arm-buildroot-linux-gnueabihf_sdk-buildroot/share/buildroot/toolchainfile.cmake",
+                "CMAKE_C_FLAGS": "-D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -D_GLIBCXX_ASSERTIONS",
+                "CMAKE_CXX_FLAGS": "-D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -D_GLIBCXX_ASSERTIONS",
+                "CMAKE_C_FLAGS_DEBUG": "-g",
+                "CMAKE_CXX_FLAGS_DEBUG": "-g",
+                "CMAKE_C_FLAGS_RELEASE": "-O3 -DNDEBUG -D_FORTIFY_SOURCE=2",
+                "CMAKE_CXX_FLAGS_RELEASE": "-O3 -DNDEBUG -D_FORTIFY_SOURCE=2"
             }
         },
         {
-            "name": "arm-release",
-            "displayName": "ARM Release",
-            "inherits": "release",
-            "binaryDir": "${sourceDir}/build/arm-release",
+            "name": "arm-buildroot-debug",
+            "displayName": "ARM Buildroot Debug",
+            "inherits": "arm-buildroot-common",
+            "binaryDir": "${sourceDir}/build/arm-buildroot-debug",
             "cacheVariables": {
-                "ARCH_ARM": "ON"
+                "CMAKE_BUILD_TYPE": "Debug"
+            }
+        },
+        {
+            "name": "arm-buildroot-release",
+            "displayName": "ARM Buildroot Release",
+            "inherits": "arm-buildroot-common",
+            "binaryDir": "${sourceDir}/build/arm-buildroot-release",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release"
             }
         }
     ],
@@ -61,12 +82,12 @@
             "configurePreset": "release"
         },
         {
-            "name": "arm-debug",
-            "configurePreset": "arm-debug"
+            "name": "arm-buildroot-debug",
+            "configurePreset": "arm-buildroot-debug"
         },
         {
-            "name": "arm-release",
-            "configurePreset": "arm-release"
+            "name": "arm-buildroot-release",
+            "configurePreset": "arm-buildroot-release"
         }
     ],
     "testPresets": [

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -12,12 +12,12 @@
             "generator": "Ninja",
             "cacheVariables": {
                 "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
-                "CMAKE_C_FLAGS": "-D_GLIBCXX_ASSERTIONS",
-                "CMAKE_CXX_FLAGS": "-D_GLIBCXX_ASSERTIONS",
-                "CMAKE_C_FLAGS_DEBUG": "-g",
-                "CMAKE_CXX_FLAGS_DEBUG": "-g",
-                "CMAKE_C_FLAGS_RELEASE": "-O3 -DNDEBUG -D_FORTIFY_SOURCE=2",
-                "CMAKE_CXX_FLAGS_RELEASE": "-O3 -DNDEBUG -D_FORTIFY_SOURCE=2"
+                "CMAKE_C_FLAGS": "-D_GLIBCXX_ASSERTIONS -D_FORTIFY_SOURCE=2",
+                "CMAKE_CXX_FLAGS": "-D_GLIBCXX_ASSERTIONS -D_FORTIFY_SOURCE=2",
+                "CMAKE_C_FLAGS_DEBUG": "-Og -g",
+                "CMAKE_CXX_FLAGS_DEBUG": "-Og -g",
+                "CMAKE_C_FLAGS_RELEASE": "-O3 -DNDEBUG",
+                "CMAKE_CXX_FLAGS_RELEASE": "-O3 -DNDEBUG"
             }
         },
         {
@@ -45,12 +45,12 @@
             "cacheVariables": {
                 "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
                 "CMAKE_TOOLCHAIN_FILE": "/opt/arm-buildroot-linux-gnueabihf_sdk-buildroot/share/buildroot/toolchainfile.cmake",
-                "CMAKE_C_FLAGS": "-D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -D_GLIBCXX_ASSERTIONS",
-                "CMAKE_CXX_FLAGS": "-D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -D_GLIBCXX_ASSERTIONS",
-                "CMAKE_C_FLAGS_DEBUG": "-g",
-                "CMAKE_CXX_FLAGS_DEBUG": "-g",
-                "CMAKE_C_FLAGS_RELEASE": "-O3 -DNDEBUG -D_FORTIFY_SOURCE=2",
-                "CMAKE_CXX_FLAGS_RELEASE": "-O3 -DNDEBUG -D_FORTIFY_SOURCE=2"
+                "CMAKE_C_FLAGS": "-D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -D_GLIBCXX_ASSERTIONS -D_FORTIFY_SOURCE=2",
+                "CMAKE_CXX_FLAGS": "-D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -D_GLIBCXX_ASSERTIONS -D_FORTIFY_SOURCE=2",
+                "CMAKE_C_FLAGS_DEBUG": "-Og -g",
+                "CMAKE_CXX_FLAGS_DEBUG": "-Og -g",
+                "CMAKE_C_FLAGS_RELEASE": "-O3 -DNDEBUG",
+                "CMAKE_CXX_FLAGS_RELEASE": "-O3 -DNDEBUG"
             }
         },
         {

--- a/README.md
+++ b/README.md
@@ -36,11 +36,11 @@ sudo update-alternatives --config gcc
 To build the library (and possibly accompanying tests), simply run `cmake` as follows:
 
 ```sh
-cmake --preset debug|release|debug-with-tests|release-with-tests
-cmake --build --preset debug|release|debug-with-tests|release-with-tests
+cmake --preset debug|release|arm-buildroot-debug|arm-buildroot-release
+cmake --build --preset debug|release|arm-buildroot-debug|arm-buildroot-release
 ```
 
-Tests can now be executed with `./rsp-core-lib-test` or `ctest --preset debug-with-tests|release-with-tests`
+Tests can now be executed with `./rsp-core-lib-test` or `ctest --preset debug|release`
 
 ## wpa_supplicant tests
 To run the wpa_supplicant tests, the /etc/wpa_supplicant/wpa_supplicant.conf file must be present and contain the following:

--- a/cmake/gcc-compile-options.cmake
+++ b/cmake/gcc-compile-options.cmake
@@ -188,23 +188,4 @@ if (NOT DEFINED RSP_GCC_STRICT_COMPILE_OPTIONS)
         #
         #-dD
     )
-
-    if(NOT DEFINED RSP_GCC_STRICT_COMPILE_DEFINITIONS)
-        set(RSP_GCC_STRICT_COMPILE_DEFINITIONS
-            # Lightweight checks to detect some buffer overflow errors when
-            # employing various string and memory manipulation functions.
-            #
-            # @see https://man7.org/linux/man-pages/man7/feature_test_macros.7.html
-            # @see https://developers.redhat.com/articles/2023/07/04/developers-guide-secure-coding-fortifysource
-            #
-            -D_FORTIFY_SOURCE=3
-
-            # Lightweight assertions that do not catch as many problems, but
-            # which are ABI compatible with normal mode.
-            #
-            # @see https://gcc.gnu.org/onlinedocs/libstdc++/manual/using_macros.html
-            #
-            -D_GLIBCXX_ASSERTIONS
-        )
-    endif()
 endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -58,6 +58,9 @@ add_executable(${TEST_BINARY})
 include("dependencies.cmake")
 rsp_core_test_add_dependencies(${TEST_BINARY})
 
+include("gcc-compile-options")
+target_compile_options(${TEST_BINARY} PRIVATE "${RSP_GCC_STRICT_COMPILE_OPTIONS}")
+
 target_include_directories(${TEST_BINARY}
     PRIVATE
         "${PROJECT_SOURCE_DIR}/src"

--- a/tests/helpers/TestHelpers.cpp
+++ b/tests/helpers/TestHelpers.cpp
@@ -80,7 +80,7 @@ bool TestHelpers::ValidateJsonFile(const std::string &arJsonFile)
 
 int TestHelpers::StartWebServer()
 {
-    std::system("killall lighttpd -q"); // Make sure it is not running
+    [[maybe_unused]] int rc = std::system("killall lighttpd -q"); // Make sure it is not running
     std::string cwd = std::filesystem::current_path();
     std::string command = cwd + "/_deps/lighttpd-build/build/lighttpd -f " + cwd + "/webserver/lighttpd.conf -m " + cwd + "/_deps/lighttpd-build/build";
     return std::system(command.c_str());

--- a/tests/unit/network/test-network.cpp
+++ b/tests/unit/network/test-network.cpp
@@ -87,7 +87,7 @@ TEST_CASE("Network")
 
         logger.Info() << "Request:\n" << request << std::endl;
 
-        IHttpResponse *resp;
+        IHttpResponse *resp = nullptr;
         CHECK_NOTHROW(resp = &request.Execute());
 
         logger.Info() << "Response:\n" << *resp << std::endl;
@@ -116,7 +116,7 @@ TEST_CASE("Network")
         opt.RequestType = HttpRequestType::HEAD;
         request.SetOptions(opt);
 
-        const IHttpResponse *resp;
+        const IHttpResponse *resp = nullptr;
         CHECK_NOTHROW(resp = &request.Execute());
 
         CHECK_EQ(resp->GetHeader("content-type"), "text/html");
@@ -195,7 +195,7 @@ TEST_CASE("Network")
 
         request.SetOptions(opt);
 
-        const IHttpResponse *resp;
+        const IHttpResponse *resp = nullptr;
         CHECK_NOTHROW(resp = &request.Execute());
 
         if constexpr (IsVerbose()) {
@@ -215,7 +215,7 @@ TEST_CASE("Network")
         opt.RequestType = HttpRequestType::HEAD;
         request.SetOptions(opt);
 
-        const IHttpResponse *resp;
+        const IHttpResponse *resp = nullptr;
         CHECK_NOTHROW(resp = &request.Execute());
 
         CHECK_EQ(resp->GetHeader("content-type"), "text/html");

--- a/tests/unit/network/test-wlan.cpp
+++ b/tests/unit/network/test-wlan.cpp
@@ -26,7 +26,7 @@ static void FetchMonitorEvents(WLan &arWlan)
 {
     std::this_thread::sleep_for(50ms);
     int retries = 2;
-    rsp::network::WpaEvents event;
+    rsp::network::WpaEvents event = rsp::network::WpaEvents::None;
     do {
         std::string msg;
         CHECK_NOTHROW(event = arWlan.GetMonitorEvent(msg));
@@ -232,7 +232,7 @@ TEST_CASE("WLAN") // * doctest::skip(wpa_supplicant_not_available()))
             CHECK_EQ(info.mSSID, std::string(cSSID));
             CHECK(info.mIpAddress.empty());
 
-            rsp::network::WpaEvents event;
+            rsp::network::WpaEvents event = rsp::network::WpaEvents::None;
             do {
                 std::string msg;
                 CHECK_NOTHROW(event = wlan.GetMonitorEvent(msg));

--- a/tests/unit/posix/test-Socket.cpp
+++ b/tests/unit/posix/test-Socket.cpp
@@ -50,7 +50,7 @@ TEST_CASE("Socket")
         CHECK(client.IsDataReady());
 
         std::string result(20, 'A');
-        size_t len;
+        size_t len = 0;
         CHECK_NOTHROW(len = client.Receive(result));
         CHECK_NOTHROW(result.resize(len));
         MESSAGE(result);
@@ -79,7 +79,7 @@ TEST_CASE("Socket")
         CHECK(client.IsDataReady());
 
         std::string result(32, 'A');
-        size_t len;
+        size_t len = 0;
         CHECK_NOTHROW(len = client.Receive(result));
         CHECK_NOTHROW(result.resize(len));
         MESSAGE(result);
@@ -115,7 +115,7 @@ TEST_CASE("Socket")
         CHECK_EQ(client.Send(hello_server), hello_server.size());
 
         std::string result(32, 'A');
-        size_t len;
+        size_t len = 0;
         Socket peer;
         CHECK(server.IsDataReady());
         CHECK_NOTHROW(len = server.ReceiveFrom(peer, result));


### PR DESCRIPTION
Setting `_FORTIFY_SOURCE` and `_GLIBCXX_ASSERTIONS` should be the
integrator's call -- not the library's. We move those to the CMake
presets for the case where we control the whole build.

`_FORTIFY_SOURCE` isn't really a "this library's code" knob because it

  - also alters code calling into the library,
  - depends on the toolchain, and it
  - must agree with optimization level (ie., doesn't work with -O0).

By putting those options in the CMakePresets.json file instead, we
ensure compatibility with, e.g., buildroot. This also allows enabling
debug-friendly optimization and setting `_FORTIFY_SOURCE` for debug 
builds which then triggered some -Werror=maybe-uninitialized to be
fixed.
