### PR TITLE
Fix failing version tests

### DIFF
--- a/include/rsp/security/Sha.h
+++ b/include/rsp/security/Sha.h
@@ -23,18 +23,19 @@ namespace rsp::security {
  * \brief Supported hash algorithms
  */
 enum class HashAlgorithms {
-    Sha1,  /**< Sha1 */
-    Sha256,/**< Sha256 */
-    Sha3   /**< Sha3 */
+    Sha1,   /**< Sha1 */
+    Sha256, /**< Sha256 */
+    Sha3    /**< Sha3 */
 };
 
 /**
  * \brief Interface class for pimpl design pattern.
  */
-struct DigestImpl {
+struct DigestImpl
+{
     static DigestImpl* Create(const SecureBuffer& arSecret, HashAlgorithms aAlgorithm);
     virtual ~DigestImpl() = default;
-    virtual void Update(const uint8_t *apBuffer, std::size_t aSize) = 0;
+    virtual void Update(const uint8_t* apBuffer, std::size_t aSize) = 0;
     virtual SecureBuffer Finalize() = 0;
     [[nodiscard]] virtual std::string GetLibraryVersion() const = 0;
     [[nodiscard]] virtual std::string GetLibraryName() const = 0;
@@ -65,7 +66,7 @@ public:
      * \param apBuffer Pointer to data
      * \param aSize Size of data
      */
-    void Update(const uint8_t *apBuffer, std::size_t aSize) { mPimpl->Update(apBuffer, aSize); }
+    void Update(const uint8_t* apBuffer, std::size_t aSize) { mPimpl->Update(apBuffer, aSize); }
 
     /**
      * \brief Get the final result of the hash calculation. The object should not longer be used after this call.
@@ -91,6 +92,6 @@ protected:
     std::unique_ptr<DigestImpl> mPimpl;
 };
 
-} /* namespace rsp::utils */
+} // namespace rsp::security
 
 #endif // RSP_CORE_LIB_SECURITY_SHA_H

--- a/include/rsp/security/Sha.h
+++ b/include/rsp/security/Sha.h
@@ -12,6 +12,7 @@
 #define RSP_CORE_LIB_SECURITY_SHA_H
 
 #include <rsp/security/SecureBuffer.h>
+#include <rsp/utils/SemVer.h>
 #include <cstdint>
 #include <vector>
 #include <memory>
@@ -37,7 +38,7 @@ struct DigestImpl
     virtual ~DigestImpl() = default;
     virtual void Update(const uint8_t* apBuffer, std::size_t aSize) = 0;
     virtual SecureBuffer Finalize() = 0;
-    [[nodiscard]] virtual std::string GetLibraryVersion() const = 0;
+    [[nodiscard]] virtual utils::Version GetLibraryVersion() const = 0;
     [[nodiscard]] virtual std::string GetLibraryName() const = 0;
 };
 
@@ -79,7 +80,7 @@ public:
      *
      * \return string
      */
-    [[nodiscard]] std::string GetLibraryVersion() const { return mPimpl->GetLibraryVersion(); }
+    [[nodiscard]] utils::Version GetLibraryVersion() const { return mPimpl->GetLibraryVersion(); }
 
     /**
      * \brief Get name of encryption library

--- a/src/security/mbedtls/ShaDigestImpl.cpp
+++ b/src/security/mbedtls/ShaDigestImpl.cpp
@@ -42,7 +42,7 @@ public:
         if (!mpDigestInfo) {
             THROW_WITH_BACKTRACE2(CryptException, "The requested algorithm is not supported: ", magic_enum::enum_name(aAlgorithm).data());
         }
-        auto rc= mbedtls_md_setup(&mDigestCtx, mpDigestInfo, aHMac);
+        auto rc = mbedtls_md_setup(&mDigestCtx, mpDigestInfo, aHMac);
         if (rc) {
             THROW_WITH_BACKTRACE2(CryptException, "mbedtls_md_setup failed", rc);
         }
@@ -70,7 +70,7 @@ public:
 
 protected:
     mbedtls_md_context_t mDigestCtx{};
-    const mbedtls_md_info_t *mpDigestInfo = nullptr;
+    const mbedtls_md_info_t* mpDigestInfo = nullptr;
 };
 
 
@@ -86,7 +86,7 @@ public:
         }
     }
 
-    void Update(const uint8_t *apBuffer, std::size_t aSize) override
+    void Update(const uint8_t* apBuffer, std::size_t aSize) override
     {
         auto rc = mbedtls_md_hmac_update(&mDigestCtx, apBuffer, aSize);
         if (rc) {
@@ -99,7 +99,7 @@ public:
         SecureBuffer result;
         result.resize(size_t(mbedtls_md_get_size(mpDigestInfo)));
 
-        auto rc= mbedtls_md_hmac_finish(&mDigestCtx, result.data());
+        auto rc = mbedtls_md_hmac_finish(&mDigestCtx, result.data());
         if (rc) {
             THROW_WITH_BACKTRACE2(CryptException, "mbedtls_md_hmac_finish failed", rc);
         }
@@ -108,11 +108,11 @@ public:
     }
 };
 
-class MbedTLSSha: public MbedTLSHDigestBase
+class MbedTLSSha : public MbedTLSHDigestBase
 {
 public:
     explicit MbedTLSSha(HashAlgorithms aAlgorithm)
-            : MbedTLSHDigestBase(aAlgorithm, 0)
+        : MbedTLSHDigestBase(aAlgorithm, 0)
     {
         auto rc = mbedtls_md_starts(&mDigestCtx);
         if (rc) {
@@ -120,7 +120,7 @@ public:
         }
     }
 
-    void Update(const uint8_t *apBuffer, std::size_t aSize) override
+    void Update(const uint8_t* apBuffer, std::size_t aSize) override
     {
         auto rc = mbedtls_md_update(&mDigestCtx, apBuffer, aSize);
         if (rc) {
@@ -133,7 +133,7 @@ public:
         SecureBuffer result;
         result.resize(size_t(mbedtls_md_get_size(mpDigestInfo)));
 
-        auto rc= mbedtls_md_finish(&mDigestCtx, result.data());
+        auto rc = mbedtls_md_finish(&mDigestCtx, result.data());
         if (rc) {
             THROW_WITH_BACKTRACE2(CryptException, "mbedtls_md_finish failed", rc);
         }

--- a/src/security/mbedtls/ShaDigestImpl.cpp
+++ b/src/security/mbedtls/ShaDigestImpl.cpp
@@ -53,11 +53,11 @@ public:
         mbedtls_md_free(&mDigestCtx);
     }
 
-    [[nodiscard]] std::string GetLibraryVersion() const override
+    [[nodiscard]] utils::Version GetLibraryVersion() const override
     {
         char result[9];
         mbedtls_version_get_string(result);
-        return result;
+        return utils::Version{result};
     }
 
     [[nodiscard]] std::string GetLibraryName() const override

--- a/src/security/openssl/ShaDigestImpl.cpp
+++ b/src/security/openssl/ShaDigestImpl.cpp
@@ -137,9 +137,9 @@ public:
         return result;
     }
 
-    [[nodiscard]] std::string GetLibraryVersion() const override
+    [[nodiscard]] utils::Version GetLibraryVersion() const override
     {
-        return OPENSSL_FULL_VERSION_STR;
+        return utils::Version{OPENSSL_FULL_VERSION_STR};
     }
 
     [[nodiscard]] std::string GetLibraryName() const override
@@ -198,9 +198,9 @@ public:
         return result;
     }
 
-    [[nodiscard]] std::string GetLibraryVersion() const override
+    [[nodiscard]] utils::Version GetLibraryVersion() const override
     {
-        return OPENSSL_FULL_VERSION_STR;
+        return utils::Version{OPENSSL_FULL_VERSION_STR};
     }
 
     [[nodiscard]] std::string GetLibraryName() const override

--- a/src/security/openssl/ShaDigestImpl.cpp
+++ b/src/security/openssl/ShaDigestImpl.cpp
@@ -31,7 +31,7 @@ public:
     OpenSSLHMac(const SecureBuffer& arSecret, HashAlgorithms aAlgorithm)
         : mpCtx(HMAC_CTX_new())
     {
-        const EVP_MD *algo;
+        const EVP_MD* algo;
         switch (aAlgorithm) {
             case HashAlgorithms::Sha1:
                 algo = EVP_sha1();
@@ -58,7 +58,7 @@ public:
     OpenSSLHMac(const OpenSSLHMac&) = delete;
     OpenSSLHMac& operator=(const OpenSSLHMac&) = delete;
 
-    void Update(const uint8_t *apBuffer, std::size_t aSize) override
+    void Update(const uint8_t* apBuffer, std::size_t aSize) override
     {
         HMAC_Update(mpCtx, apBuffer, aSize);
     }
@@ -76,7 +76,7 @@ public:
     }
 
 protected:
-    HMAC_CTX *mpCtx;
+    HMAC_CTX* mpCtx;
 };
 
 #else // OPENSSL_VERSION_NUMBER < 0x30000000L
@@ -85,8 +85,8 @@ class OpenSSLHMac : public DigestImpl
 {
 public:
     OpenSSLHMac(const SecureBuffer& arSecret, HashAlgorithms aAlgorithm)
-        : mpMac(EVP_MAC_fetch(nullptr, "HMAC", nullptr)),
-          mpCtx(EVP_MAC_CTX_new(mpMac))
+        : mpMac(EVP_MAC_fetch(nullptr, "HMAC", nullptr))
+        , mpCtx(EVP_MAC_CTX_new(mpMac))
     {
         std::string algo;
         switch (aAlgorithm) {
@@ -119,7 +119,7 @@ public:
     OpenSSLHMac(const OpenSSLHMac&) = delete;
     OpenSSLHMac& operator=(const OpenSSLHMac&) = delete;
 
-    void Update(const uint8_t *apBuffer, std::size_t aSize) override
+    void Update(const uint8_t* apBuffer, std::size_t aSize) override
     {
         EVP_MAC_update(mpCtx, apBuffer, aSize);
     }
@@ -148,13 +148,13 @@ public:
     }
 
 protected:
-    EVP_MAC * mpMac;
-    EVP_MAC_CTX *mpCtx;
+    EVP_MAC* mpMac;
+    EVP_MAC_CTX* mpCtx;
 };
 
 #endif
 
-class OpenSSLSha: public DigestImpl
+class OpenSSLSha : public DigestImpl
 {
 public:
     explicit OpenSSLSha(HashAlgorithms aAlgorithm)
@@ -178,10 +178,10 @@ public:
         }
 
         EVP_DigestInit_ex(mpMdctx, md, nullptr);
-//        EVP_DigestInit_ex2(mpMdctx, md, nullptr);
+        // EVP_DigestInit_ex2(mpMdctx, md, nullptr);
     }
 
-    void Update(const uint8_t *apBuffer, std::size_t aSize) override
+    void Update(const uint8_t* apBuffer, std::size_t aSize) override
     {
         EVP_DigestUpdate(mpMdctx, apBuffer, aSize);
     }

--- a/tests/unit/security/test-Sha.cpp
+++ b/tests/unit/security/test-Sha.cpp
@@ -12,6 +12,7 @@
 #include <string>
 #include <rsp/security/Sha.h>
 #include <rsp/security/SecureString.h>
+#include <rsp/utils/SemVer.h>
 
 using namespace rsp::security;
 
@@ -31,10 +32,10 @@ TEST_CASE("SHA")
         Sha sha(HashAlgorithms::Sha3);
 #ifdef USE_OPENSSL
         CHECK_EQ(sha.GetLibraryName(), std::string("openssl"));
-        CHECK_EQ(sha.GetLibraryVersion(), std::string("3.5.5"));
+        CHECK_GE(sha.GetLibraryVersion(), rsp::utils::Version{"3.5.5"});
 #elif defined(USE_MBEDTLS)
         CHECK_EQ(sha.GetLibraryName(), std::string("MbedTLS"));
-        CHECK_EQ(sha.GetLibraryVersion(), std::string("3.6.0"));
+        CHECK_EQ(sha.GetLibraryVersion(), rsp::utils::Version{"3.6.0"});
 #endif
     }
 

--- a/tests/unit/security/test-Sha.cpp
+++ b/tests/unit/security/test-Sha.cpp
@@ -32,10 +32,10 @@ TEST_CASE("SHA")
         Sha sha(HashAlgorithms::Sha3);
 #ifdef USE_OPENSSL
         CHECK_EQ(sha.GetLibraryName(), std::string("openssl"));
-        CHECK_GE(sha.GetLibraryVersion(), rsp::utils::Version{"3.5.5"});
+        CHECK_GE(sha.GetLibraryVersion(), rsp::utils::Version{"3.0.13"});
 #elif defined(USE_MBEDTLS)
         CHECK_EQ(sha.GetLibraryName(), std::string("MbedTLS"));
-        CHECK_EQ(sha.GetLibraryVersion(), rsp::utils::Version{"3.6.0"});
+        CHECK_GE(sha.GetLibraryVersion(), rsp::utils::Version{"3.6.0"});
 #endif
     }
 

--- a/tests/unit/security/test-Sha.cpp
+++ b/tests/unit/security/test-Sha.cpp
@@ -27,8 +27,7 @@ TEST_CASE("SHA")
 {
     const std::string test_str("How much wood would a woodchuck chuck, if a woodchuck would chuck wood.");
 
-    SUBCASE("Library Version")
-    {
+    SUBCASE("Library Version") {
         Sha sha(HashAlgorithms::Sha3);
 #ifdef USE_OPENSSL
         CHECK_EQ(sha.GetLibraryName(), std::string("openssl"));
@@ -39,8 +38,7 @@ TEST_CASE("SHA")
 #endif
     }
 
-    SUBCASE("SHA1-HMAC")
-    {
+    SUBCASE("SHA1-HMAC") {
         Sha sha("MySecret", HashAlgorithms::Sha1);
         sha.Update(reinterpret_cast<const uint8_t*>(test_str.data()), test_str.size());
         SecureString md = sha.Get().GetHex();
@@ -48,8 +46,7 @@ TEST_CASE("SHA")
         CHECK_EQ(md, "78bb1131dcdfe96b4a0eb2de9cb0d8ed75dec97f");
     }
 
-    SUBCASE("SHA256-HMAC")
-    {
+    SUBCASE("SHA256-HMAC") {
         Sha sha("MySecret", HashAlgorithms::Sha256);
         sha.Update(reinterpret_cast<const uint8_t*>(test_str.data()), test_str.size());
         SecureString md = sha.Get().GetHex();
@@ -57,8 +54,7 @@ TEST_CASE("SHA")
         CHECK_EQ(md, "3937baa5432706e916264cb43ce87c02bd4939ee2588bfbe2cec19b978ccf48d");
     }
 
-    SUBCASE("SHA3-HMAC")
-    {
+    SUBCASE("SHA3-HMAC") {
         Sha sha("MySecret", HashAlgorithms::Sha3);
         sha.Update(reinterpret_cast<const uint8_t*>(test_str.data()), test_str.size());
         SecureString md = sha.Get().GetHex();
@@ -70,8 +66,7 @@ TEST_CASE("SHA")
         CHECK_EQ(md, "3ee16249305308e171910e27e1eb66803db4389696b49b2cd08b38e3cc2114dd");
     }
 
-    SUBCASE("SHA1")
-    {
+    SUBCASE("SHA1") {
         Sha sha(HashAlgorithms::Sha1);
         sha.Update(reinterpret_cast<const uint8_t*>(test_str.data()), test_str.size());
         SecureString md = sha.Get().GetHex();
@@ -79,8 +74,7 @@ TEST_CASE("SHA")
         CHECK_EQ(md, "56e581dcc416215b41474b7d269f11bcbe7ab3e2");
     }
 
-    SUBCASE("SHA256")
-    {
+    SUBCASE("SHA256") {
         Sha sha(HashAlgorithms::Sha256);
         sha.Update(reinterpret_cast<const uint8_t*>(test_str.data()), test_str.size());
         SecureString md = sha.Get().GetHex();
@@ -88,15 +82,13 @@ TEST_CASE("SHA")
         CHECK_EQ(md, "242fdbb7f8993f14f6fdad9098ca4d0f102760debbee49c76aae404073e84ed3");
     }
 
-    SUBCASE("SHA3")
-    {
+    SUBCASE("SHA3") {
         Sha sha(HashAlgorithms::Sha3);
         sha.Update(reinterpret_cast<const uint8_t*>(test_str.data()), test_str.size());
         SecureString md = sha.Get().GetHex();
 
         CHECK_EQ(md, "ea90f6707eaa4444a9ef4828fd67e31b43f591a487d77a5ad207399da387faea");
     }
-
 }
 
 TEST_SUITE_END();


### PR DESCRIPTION
Hash library version tests were failing. Since #15 we can now use that utility to compare version numbers according to the SemVer scheme.

I relaxed tests to require 
  - openssl >= 3.0.13 (this is the version on my Ubuntu 24.04)
  - MBedTLS >= 3.6.0